### PR TITLE
Fix command line for add-apt-repository

### DIFF
--- a/try-landscape.html
+++ b/try-landscape.html
@@ -194,7 +194,7 @@
                         </div>
                         <div class="seven-col last-col instruction__details">
                             <p class="command-line">
-                                <input class="command-line__input" value="sudo add-apt-repository ppa: landscape/15.11" readonly="readonly">
+                                <input class="command-line__input" value="sudo add-apt-repository ppa:landscape/15.11" readonly="readonly">
                                 <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
                             </p>
                         </div>


### PR DESCRIPTION
One-liner change to the instructions on the try-landscape page, to fix the command line for add-apt-repository